### PR TITLE
fix: Improve DA3 import robustness for RunPod/nightly PyTorch environ…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("DepthEstimation")
 
 # Version info
-__version__ = "1.3.3"
+__version__ = "1.3.6"
 
 # Node class mappings - will be populated based on dependency checks
 NODE_CLASS_MAPPINGS = {}
@@ -58,19 +58,20 @@ for module_name, min_version in required_dependencies.items():
 
 # Check optional DA3 dependencies
 for module_name, min_version in optional_dependencies.items():
+    module_version = None  # Initialize BEFORE try block to fix scoping issue
     try:
         module = __import__(module_name)
         module_version = getattr(module, "__version__", "0.0.0")
-        
+
         logger.info(f"Found optional {module_name} version {module_version}")
-        
+
     except ImportError:
         logger.info(f"Optional dependency {module_name} not installed. DA3 models will not be available.")
     except Exception as e:
         logger.warning(f"Error checking version for {module_name}: {e}. DA3 models might not work correctly.")
 
-    # Version comparison
-    if module_name == "depth_anything_3" and "module_version" in locals():
+    # Version comparison - now module_version is always defined
+    if module_name == "depth_anything_3" and module_version is not None:
         try:
             # Compare versions. This simple check works for "X.Y.Z" formats.
             if tuple(map(int, module_version.split('.'))) >= tuple(map(int, min_version.split('.'))):

--- a/depth_estimation_node.py
+++ b/depth_estimation_node.py
@@ -30,16 +30,21 @@ except ImportError:
     TIMM_AVAILABLE = False
     print("Warning: timm not available. Direct loading of Depth Anything models may not work.")
 
+# Get logger instance (basicConfig is called in __init__.py)
+logger = logging.getLogger("DepthEstimation")
+
 # Import DA3 availability status from the package's __init__
 from . import DA3_AVAILABLE
 
 # Conditionally import Depth Anything V3 if available
+# Use defensive import guard to handle edge cases where DA3_AVAILABLE check passes
+# but the actual import still fails (e.g., corrupted install, version mismatch)
 if DA3_AVAILABLE:
-    from depth_anything_3.api import DepthAnything3
-
-# Setup logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("DepthEstimation")
+    try:
+        from depth_anything_3.api import DepthAnything3
+    except ImportError as e:
+        DA3_AVAILABLE = False
+        logger.warning(f"DA3 import failed despite availability check: {e}. DA3 models disabled.")
 
 # Depth Anything V2 Implementation
 class DepthAnythingV2(nn.Module):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyuidepthestimation"
 description = "A robust custom depth estimation node for ComfyUI using Depth-Anything models (V1, V2, and V3/DA3). It integrates depth estimation with configurable post-processing options including blur, median filtering, contrast enhancement, and gamma correction."
-version = "1.3.5"
+version = "1.3.6"
 license = { file = "LICENSE" }
 dependencies = [
     "transformers>=4.20.0",


### PR DESCRIPTION
…ments

- Fix scoping bug in __init__.py where module_version was undefined after ImportError, causing incorrect DA3_AVAILABLE check
- Add defensive try/except guard around depth_anything_3 import in depth_estimation_node.py to handle edge cases
- Move logger initialization before DA3 import to prevent NameError
- Bump version to 1.3.6

Resolves node loading failures on RunPod with PyTorch nightly builds where the error node "Depth Estimation (Error)" was incorrectly shown even when DA3 was intentionally not installed.