### PR TITLE
feat: add DA3 v1.1 models and fix duplicate error message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ComfyUI Depth Estimation Node is a custom node for ComfyUI that provides depth map generation from images using Depth-Anything models (V1, V2, and V3). The node integrates with ComfyUI's workflow system and provides configurable post-processing options. **Version 1.3.4+ adds Depth-Anything V3 support with camera pose estimation (extrinsics/intrinsics). Version 1.3.7 fixes missing `import json` (#18) and cleans up PEP 8 import ordering.**
+ComfyUI Depth Estimation Node is a custom node for ComfyUI that provides depth map generation from images using Depth-Anything models (V1, V2, and V3). The node integrates with ComfyUI's workflow system and provides configurable post-processing options. **Version 1.3.4+ adds Depth-Anything V3 support with camera pose estimation (extrinsics/intrinsics). Version 1.3.8 adds DA3 v1.1 models and fixes duplicate error message.**
 
 ## Development Commands
 
@@ -46,7 +46,8 @@ The project uses ComfyUI Registry for distribution:
 The node supports multiple depth estimation models defined in `DEPTH_MODELS` dictionary:
 - **Depth-Anything V1**: Small, Base, Large variants
 - **Depth-Anything V2**: Small, Base variants
-- **Depth-Anything V3**: Small, Base variants (Apache 2.0, with camera pose estimation)
+- **Depth-Anything V3**: Small, Base, Large, Giant, Nested-Giant-Large, Mono-Large, Metric-Large variants
+- **Depth-Anything V3 v1.1**: Large-1.1, Giant-1.1, Nested-Giant-Large-1.1 (updated models with improved performance)
 
 Each model entry includes: HuggingFace path, VRAM requirements, direct download URL, model type, encoder type, and `supports_pose` flag.
 
@@ -163,6 +164,7 @@ When modifying or extending this node:
 
 ## Version History
 
+- **v1.3.8** (2026-03-09): Added DA3 v1.1 models (Large-1.1, Giant-1.1, Nested-Giant-Large-1.1), fixed duplicate error message in DA3 loading
 - **v1.3.7** (2026-02-16): Fixed missing `import json` causing NameError (#18), PEP 8 import grouping, removed redundant local import
 - **v1.3.6** (2025-12-08): Fixed scoping bug in optional dependency checker, added defensive import guards for DA3, improved compatibility with PyTorch nightly builds
 - **v1.3.5**: DA3 camera pose estimation feature release

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("DepthEstimation")
 
 # Version info
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 # Node class mappings - will be populated based on dependency checks
 NODE_CLASS_MAPPINGS = {}

--- a/depth_estimation_node.py
+++ b/depth_estimation_node.py
@@ -389,6 +389,37 @@ DEPTH_MODELS = {
         "params": "350M",
         "note": "Metric depth only, no camera estimation"
     },
+    "Depth-Anything-V3-Large-1.1": {
+        "path": "depth-anything/DA3-LARGE-1.1",
+        "vram_mb": 4000,
+        "model_type": "v3",
+        "encoder": "vitl",
+        "license": "Apache-2.0",
+        "supports_batch": True,
+        "supports_pose": True,
+        "params": "350M"
+    },
+    "Depth-Anything-V3-Giant-1.1": {
+        "path": "depth-anything/DA3-GIANT-1.1",
+        "vram_mb": 6000,
+        "model_type": "v3",
+        "encoder": "vitg",
+        "license": "CC BY-NC 4.0",
+        "supports_batch": True,
+        "supports_pose": True,
+        "params": "1.15B"
+    },
+    "Depth-Anything-V3-Nested-Giant-Large-1.1": {
+        "path": "depth-anything/DA3NESTED-GIANT-LARGE-1.1",
+        "vram_mb": 7000,
+        "model_type": "v3",
+        "encoder": "nested",
+        "license": "CC BY-NC 4.0",
+        "supports_batch": True,
+        "supports_pose": True,
+        "metric_scaling": True,
+        "params": "1.4B"
+    },
 }
 
 class MiDaSWrapper:
@@ -1052,8 +1083,6 @@ class DepthEstimationNode:
             if model_type == "v3":
                 if not DA3_AVAILABLE:
                     raise RuntimeError(
-                        f"DA3 model '{model_name}' requested but depth_anything_v3 package not installed. "
-                        "Please install with: pip install depth-anything-v3"
                         f"DA3 model '{model_name}' requested but depth_anything_3 package not installed. "
                         "Please install with: pip install depth-anything-3"
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyuidepthestimation"
 description = "A robust custom depth estimation node for ComfyUI using Depth-Anything models (V1, V2, and V3/DA3). It integrates depth estimation with configurable post-processing options including blur, median filtering, contrast enhancement, and gamma correction."
-version = "1.3.7"
+version = "1.3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "transformers>=4.20.0",


### PR DESCRIPTION
- Add Depth-Anything-V3-Large-1.1, Giant-1.1, Nested-Giant-Large-1.1 to DEPTH_MODELS
- Fix duplicate RuntimeError string with conflicting package names
- Bump version to 1.3.8